### PR TITLE
fix paths for windows

### DIFF
--- a/lib/Catmandu/DirectoryIndex/Number.pm
+++ b/lib/Catmandu/DirectoryIndex/Number.pm
@@ -146,6 +146,9 @@ sub generator {
 
         return unless defined $path;
 
+        #Path::Iterator::Rule hardcodes forward slashes
+        $path =~ s/\//\\/go if $^O eq "MSWin32";
+
         my $id = $self->_from_path($path);
 
         +{_id => $id, _path => $path};

--- a/lib/Catmandu/DirectoryIndex/UUID.pm
+++ b/lib/Catmandu/DirectoryIndex/UUID.pm
@@ -138,6 +138,9 @@ sub generator {
 
         return unless defined $path;
 
+        #Path::Iterator::Rule hardcodes forward slashes
+        $path =~ s/\//\\/go if $^O eq "MSWin32";
+
 #TODO: does not throw an error when directory is less than 12 levels (because no directories are validated)
         my $id = $self->_from_path($path);
 

--- a/t/Catmandu-DirectoryIndex-Map.t
+++ b/t/Catmandu-DirectoryIndex-Map.t
@@ -5,7 +5,6 @@ use Test::More;
 use Test::Exception;
 use File::Temp;
 use File::Spec;
-use Cwd;
 use Path::Tiny;
 
 my $pkg;
@@ -19,7 +18,7 @@ require_ok $pkg;
 require_ok "Catmandu::Store::Hash";
 
 my $t = File::Temp->newdir(EXLOCK => 0, UNLINK => 1);
-my $dir = Cwd::abs_path($t->dirname);
+my $dir = $t->dirname;
 
 ok(
     $pkg->new(base_dir => $dir, store_name => "Hash", bag_name => "data")


### PR DESCRIPTION
Path::Iterator::Rule hardcodes forward slashes, even for Windows.
This pull request replaces forward slashes by backward slashes when
windows is detected.